### PR TITLE
feat: add profile for public organization view

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,14 @@
+# Hapag-Lloyd AG
+
+This is the public view of our organization.
+
+## Become a member
+
+Please create a merge request in our internal repository "Infrastructure - Hapag-Lloyd GitHub Organization". Add a new resource to the file `members.tf` as shown below.
+
+```hcl
+resource "github_membership" "first_last_name" {
+  username = "github_user_id"
+  role     = "member"
+}
+```


### PR DESCRIPTION
Add a section to the public profile of the Hapag-Lloyd organization and explain how to become a member.